### PR TITLE
Passive dialogue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1014,12 +1014,12 @@ impl eframe::App for DialogueApp {
 
                                 if success {
                                     if let Some(success_text) = &passive_check.success_text {
-                                        ui.heading(&format!("{} says:", passive_check.success_speaker.clone().unwrap_or("Narrator".to_string())));
+                                        ui.heading(&format!("{} says:", passive_check.speaker.clone().unwrap_or("Narrator".to_string())));
                                         ui.label(success_text);
                                     }
                                 } else {
                                     if let Some(failure_text) = &passive_check.failure_text {
-                                        ui.heading(&format!("{} says:", passive_check.failure_speaker.clone().unwrap_or("Narrator".to_string())));
+                                        ui.heading(&format!("{} says:", passive_check.speaker.clone().unwrap_or("Narrator".to_string())));
                                         ui.label(failure_text);
                                     }
                                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1006,20 +1006,20 @@ impl eframe::App for DialogueApp {
                         if let Some(current_dialogue) = self.get_current_dialogue_from_id(current_dialogue_id) {
 
 
-                            // Handle the passive check if it exists
-                            if let Some(passive_check) = &current_dialogue.passive_check {
+                            // Handle multiple passive checks if they exist
+                            for passive_check in &current_dialogue.passive_checks {
                                 // Perform the skill check
-                                let player_skill_value = self.get_player_skill(&passive_check.skill) + 6;
+                                let player_skill_value = self.get_player_skill(&passive_check.skill);
                                 let success = player_skill_value >= passive_check.target;
-                                
+
                                 if success {
                                     if let Some(success_text) = &passive_check.success_text {
-                                        ui.heading(&format!("{} ", passive_check.speaker.clone().unwrap_or("Narrator".to_string())));
+                                        ui.heading(&format!("{} says:", passive_check.success_speaker.clone().unwrap_or("Narrator".to_string())));
                                         ui.label(success_text);
                                     }
                                 } else {
                                     if let Some(failure_text) = &passive_check.failure_text {
-                                        ui.heading(&format!("{} ", passive_check.speaker.clone().unwrap_or("Narrator".to_string())));
+                                        ui.heading(&format!("{} says:", passive_check.failure_speaker.clone().unwrap_or("Narrator".to_string())));
                                         ui.label(failure_text);
                                     }
                                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -980,7 +980,7 @@ impl eframe::App for DialogueApp {
                             // Handle the passive check if it exists
                             if let Some(passive_check) = &current_dialogue.passive_check {
                                 // Perform the skill check
-                                let player_skill_value = self.get_player_skill(&passive_check.skill);
+                                let player_skill_value = self.get_player_skill(&passive_check.skill) + 6;
                                 let success = player_skill_value >= passive_check.target;
                                 
                                 if success {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1409,17 +1409,6 @@ impl Default for Dialogue {
     }
 }
 
-//not clea this needs to be a separate Dialogue type, since we also want it to live in the regular hashmap
-
-// #[derive(Clone)]
-// struct PassiveDialogue{
-//     skill: String,
-//     passive_number: i32,
-//     dialogue: Dialogue,
-// }
-
-//set defaults friendly to passive dialogue for regular dialogue
-
 
 fn main() {
     let app = DialogueApp::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1134,11 +1134,23 @@ impl DialogueApp {
 
     fn get_player_skill(&self, skill: &str) -> i32 {
         match skill {
-            "tech" => self.player.tech,
-            "arts" => self.player.arts,
-            "bureaucracy" => self.player.bur,
-            "underworld" => self.player.und,
-            _ => 0,  // Default to 0 if the skill doesn't exist
+            "checkmate" => self.player.checkmate(),
+            "rocketry" => self.player.rocketry(),
+            "pathology" => self.player.pathology(),
+            "civic engineering" => self.player.civic_engineering(),
+            "apparatchik" => self.player.apparatchik(),
+            "quota" => self.player.quota(),
+            "robot" => self.player.robot(),
+            "dossier" => self.player.dossier(),
+            "delusion" => self.player.delusion(),
+            "arts2" => self.player.arts2(),
+            "arts3" => self.player.arts3(),
+            "arts4" => self.player.arts4(),
+            "high proof" => self.player.high_proof(),
+            "prohibition" => self.player.prohibition(),
+            "gizmo" => self.player.gizmo(),
+            "oldtime religion" => self.player.oldtime_religion(),
+            _ => 0, // Default to 0 if the skill doesn't exist
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,14 +93,14 @@ impl Default for DialogueApp {
                 passive_check: vec![
                     PassiveCheck {
                         skill: "robot".to_string(),
-                        target: 8,
+                        target: 10,
                         success_text: Some("You know its kind. The unrelenting metronome to which you dance.".to_string()),
                         failure_text: None,
                         speaker: Some("Robot".to_string())
                     },
                     PassiveCheck {
                         skill: "gizmo".to_string(),
-                        target: 10,
+                        target: 12,
                         success_text: Some("It's in bad shape, boss. The varnish is falling off, the face needs a solid wipe down, 
                         and I don't see a notice of last maintenance *anywhere*.".to_string()),
                         failure_text: None,
@@ -1023,9 +1023,9 @@ impl eframe::App for DialogueApp {
 
 
                             // Handle multiple passive checks if they exist
-                            for passive_check in &current_dialogue.passive_checks {
+                            for passive_check in &current_dialogue.passive_check {
                                 // Perform the skill check
-                                let player_skill_value = self.get_player_skill(&passive_check.skill);
+                                let player_skill_value = self.get_player_skill(&passive_check.skill) + 6;
                                 let success = player_skill_value >= passive_check.target;
 
                                 if success {
@@ -1256,41 +1256,6 @@ fn roll_dice() -> (i32, i32) {
 }
 
 
-fn handle_passive(player: &Player, option: &DialogueOption) -> bool {
-    if let Some(challenge_attribute) = &option.challenge_attribute {
-        if let Some(challenge_number) = option.challenge_number {
-            let attribute_value = match challenge_attribute.as_str() {
-                "checkmate" => player.checkmate(),
-                "rocketry" => player.rocketry(),
-                "pathology" => player.pathology(),
-                "civic engineering" => player.civic_engineering(),
-                "apparatchik" => player.apparatchik(),
-                "quota" => player.quota(),
-                "robot" => player.robot(),
-                "dossier" => player.dossier(),
-                "delusion" => player.delusion(),
-                "arts2" => player.arts2(),
-                "arts3" => player.arts3(),
-                "arts4" => player.arts4(),
-                "high proof" => player.high_proof(),
-                "prohibition" => player.prohibition(),
-                "gizmo" => player.gizmo(),
-                "oldtime religion" => player.oldtime_religion(),
-                _ => 0,
-            };
-
-            let total = 6 + attribute_value;
-            if total >= challenge_number {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    }
-    false
-}
-
-
 struct Player {
     tech: i32,
     arts: i32,
@@ -1433,6 +1398,7 @@ struct Dialogue {
     is_hidden: bool,
 }
 
+#[derive(Clone)]
 struct PassiveCheck {
     skill: String,          // The player's skill to check
     target: i32,            // The number to check against

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ impl Default for DialogueApp {
         vestibule_dialogues.insert(
             "Start".to_string(),
             Dialogue {
-            speaker: "".to_string(),
-            intro: "The front door swings shut, cutting off the bitter wind like a scythe. You stand in the harsh light of a public apartment vestibule. A grandfather clock stands stout against the wall, like an elderly servant whose crooked back can't quite stand up to attention.".to_string(),
+                speaker: "".to_string(),
+                intro: "The front door swings shut, cutting off the bitter wind like a scythe. You stand in the harsh light of a public apartment vestibule. A grandfather clock stands stout against the wall, like an elderly servant whose crooked back can't quite stand up to attention.".to_string(),
                 options: vec![
                     DialogueOption {
                         description: "Inspect the grandfather clock.".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: false,
             },
         );
@@ -89,6 +90,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             },
         );
@@ -108,6 +110,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -154,6 +157,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -200,6 +204,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -228,6 +233,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -256,6 +262,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -293,6 +300,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -348,6 +356,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -376,6 +385,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -395,6 +405,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true, //grandfather clockovitch is a secret religionist! asks that you forgive him anyway. Will you hold back your generosity from this sinne- I mean, reactionary?
             }
         );
@@ -423,6 +434,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -460,6 +472,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -488,6 +501,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -516,6 +530,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -535,6 +550,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -554,6 +570,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -573,6 +590,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -624,6 +642,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -643,6 +662,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -662,6 +682,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -689,6 +710,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -719,6 +741,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -741,6 +764,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: true,
             }
         );
@@ -779,6 +803,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: false,
             },
         );
@@ -799,6 +824,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: false,
             },
         );
@@ -818,6 +844,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: false,
             },
         );
@@ -847,6 +874,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: false,
             },
         );
@@ -867,6 +895,7 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
+                passive_check: vec![],
                 is_hidden: false,
             },
         );
@@ -1384,7 +1413,7 @@ struct Dialogue {
     speaker: String,
     intro: String,
     options: Vec<DialogueOption>,
-    passive_check: Option<PassiveCheck>, // New field for passive dialogue checks
+    passive_check: Vec<PassiveCheck>, // New field for passive dialogue checks
     is_hidden: bool,
 }
 
@@ -1404,7 +1433,7 @@ impl Default for Dialogue {
             options: vec![
                 DialogueOption::default(),
             ],
-            passive_check: None, 
+            passive_check: vec![],
             is_hidden: true,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,6 @@ struct DialogueApp {
     previous_dialogue_id: Option<String>,
 }
 
-struct PassiveDialogue{
-
-}
-
 impl Default for DialogueApp {
     fn default() -> Self {
         let mut locations = HashMap::new();
@@ -979,6 +975,26 @@ impl eframe::App for DialogueApp {
             
                     if let Some(current_dialogue_id) = &current_dialogue_id_clone {
                         if let Some(current_dialogue) = self.get_current_dialogue_from_id(current_dialogue_id) {
+
+
+                            // Handle the passive check if it exists
+                            if let Some(passive_check) = &current_dialogue.passive_check {
+                                // Perform the skill check
+                                let player_skill_value = self.get_player_skill(&passive_check.skill);
+                                let success = player_skill_value >= passive_check.target;
+                                
+                                if success {
+                                    if let Some(success_text) = &passive_check.success_text {
+                                        ui.heading(&format!("{} ", passive_check.speaker.clone().unwrap_or("Narrator".to_string())));
+                                        ui.label(success_text);
+                                    }
+                                } else {
+                                    if let Some(failure_text) = &passive_check.failure_text {
+                                        ui.heading(&format!("{} ", passive_check.speaker.clone().unwrap_or("Narrator".to_string())));
+                                        ui.label(failure_text);
+                                    }
+                                }
+                            }
             
                             // Display the speaker's name before the dialogue
                             ui.heading(&format!("{} ", current_dialogue.speaker));
@@ -1346,7 +1362,16 @@ struct Dialogue {
     speaker: String,
     intro: String,
     options: Vec<DialogueOption>,
+    passive_check: Option<PassiveCheck>, // New field for passive dialogue checks
     is_hidden: bool,
+}
+
+struct PassiveCheck {
+    skill: String,          // The player's skill to check
+    target: i32,            // The number to check against
+    success_text: Option<String>, // Text to display on success (Optional)
+    failure_text: Option<String>, // Text to display on failure (Optional)
+    speaker: Option<String>, // The speaker, who will be the same in both success and failure cases
 }
 
 impl Default for Dialogue {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1404,6 +1404,7 @@ impl Default for Dialogue {
             options: vec![
                 DialogueOption::default(),
             ],
+            passive_check: None, 
             is_hidden: true,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,23 @@ impl Default for DialogueApp {
                         item_to_pickup: None,
                     },
                 ],
-                passive_check: vec![],
+                passive_check: vec![
+                    PassiveCheck {
+                        skill: "robot".to_string(),
+                        target: 8,
+                        success_text: Some("You know its kind. The unrelenting metronome to which you dance.".to_string()),
+                        failure_text: None,
+                        speaker: Some("Robot".to_string())
+                    },
+                    PassiveCheck {
+                        skill: "gizmo".to_string(),
+                        target: 10,
+                        success_text: Some("It's in bad shape, boss. The varnish is falling off, the face needs a solid wipe down, 
+                        and I don't see a notice of last maintenance *anywhere*.".to_string()),
+                        failure_text: None,
+                        speaker: Some("Gizmo".to_string())
+                    },
+                ],
                 is_hidden: true,
             },
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1131,6 +1131,16 @@ impl DialogueApp {
             ui.label("No dialogue available.");
         }
     }
+
+    fn get_player_skill(&self, skill: &str) -> i32 {
+        match skill {
+            "tech" => self.player.tech,
+            "arts" => self.player.arts,
+            "bureaucracy" => self.player.bur,
+            "underworld" => self.player.und,
+            _ => 0,  // Default to 0 if the skill doesn't exist
+        }
+    }
 }
 
 // Challenge logic


### PR DESCRIPTION
added ability to make multiple passive dialogue checks. Currently they just print above the rest of the dialogue, instead of requiring a continue button press. Also, no current ability to make whether one activates dependent on the previous one. Pretty basic, but functional